### PR TITLE
feat: improving  tls flow

### DIFF
--- a/examples/tls.mts
+++ b/examples/tls.mts
@@ -1,0 +1,41 @@
+import {Cluster, VerifyMode} from "../index.js"
+
+const nodes = process.env.CLUSTER_NODES?.split(",") ?? ["localhost:9142"];
+console.log(`Connecting to ${nodes}`);
+
+const cluster = new Cluster({
+    nodes,
+    ssl: {
+        enabled: true,
+        truststoreFilepath: "/your/path/to/certificates/client_cert.pem",
+        privateKeyFilepath: "/your/path/to/certificates/client_key.pem",
+        caFilepath: "/your/path/to/certificates/client_truststore.pem",
+        verifyMode: VerifyMode.Peer,
+    }
+});
+
+const session = await cluster.connect();
+
+interface ConnectedClient {
+    address: String,
+    port: number,
+    username: String,
+    driver_name: String,
+    driver_version: String,
+}
+
+// @ts-ignore
+let result = await session.execute<ConnectedClient>("SELECT address, port, username, driver_name, driver_version FROM system.clients");
+
+console.log(result)
+// [
+//  {
+//     address: '127.0.0.1',
+//     driver_name: 'scylla-rust-driver',
+//     driver_version: '0.10.1',
+//     port: 58846,
+//     username: 'developer'
+//  }
+// ]
+
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,10 @@ export interface Auth {
   password: string
 }
 export interface Ssl {
-  caFilepath: string
+  enabled: boolean
+  caFilepath?: string
+  privateKeyFilepath?: string
+  truststoreFilepath?: string
   verifyMode?: VerifyMode
 }
 export const enum VerifyMode {
@@ -89,7 +92,7 @@ export interface ScyllaMaterializedView {
   baseTableName: string
 }
 export type ScyllaCluster = Cluster
-export class Cluster {
+export declare class Cluster {
   /**
    * Object config is in the format:
    * {
@@ -108,7 +111,7 @@ export type ScyllaBatchStatement = BatchStatement
  * These statements can be simple or prepared.
  * Only INSERT, UPDATE and DELETE statements are allowed.
  */
-export class BatchStatement {
+export declare class BatchStatement {
   constructor()
   /**
    * Appends a statement to the batch.
@@ -118,17 +121,17 @@ export class BatchStatement {
    */
   appendStatement(statement: Query | PreparedStatement): void
 }
-export class PreparedStatement {
+export declare class PreparedStatement {
   setConsistency(consistency: Consistency): void
   setSerialConsistency(serialConsistency: SerialConsistency): void
 }
-export class Query {
+export declare class Query {
   constructor(query: string)
   setConsistency(consistency: Consistency): void
   setSerialConsistency(serialConsistency: SerialConsistency): void
   setPageSize(pageSize: number): void
 }
-export class Metrics {
+export declare class Metrics {
   /** Returns counter for nonpaged queries */
   getQueriesNum(): bigint
   /** Returns counter for pages requested in paged queries */
@@ -148,7 +151,7 @@ export class Metrics {
    */
   getLatencyPercentileMs(percentile: number): bigint
 }
-export class ScyllaSession {
+export declare class ScyllaSession {
   metrics(): Metrics
   getClusterData(): Promise<ScyllaClusterData>
   execute(query: string | Query | PreparedStatement, parameters?: Array<number | string | Uuid> | undefined | null): Promise<any>
@@ -261,14 +264,14 @@ export class ScyllaSession {
   awaitSchemaAgreement(): Promise<Uuid>
   checkSchemaAgreement(): Promise<boolean>
 }
-export class ScyllaClusterData {
+export declare class ScyllaClusterData {
   /**
    * Access keyspaces details collected by the driver Driver collects various schema details like
    * tables, partitioners, columns, types. They can be read using this method
    */
   getKeyspaceInfo(): Record<string, ScyllaKeyspace> | null
 }
-export class Uuid {
+export declare class Uuid {
   /** Generates a random UUID v4. */
   static randomV4(): Uuid
   /** Parses a UUID from a string. It may fail if the string is not a valid UUID. */


### PR DESCRIPTION
## Motivation

I'm writing an article on how easy it's suppose to be to setup TLS/SSL with ScyllaDB and one of the examples which I want to add is using JS. ATM the driver only support the Certificate without Keys/Truststore and this pull request adds this specific support.


```js
// Before 
const cluster = new Cluster({
    nodes,
    ssl: {
        caFilepath: "/your/path/to/certificates/client_truststore.pem",
        verifyMode: VerifyMode.Peer,
    }
});


// After
const cluster = new Cluster({
    nodes,
    ssl: {
        enabled: true, // Feature Flag
        truststoreFilepath: "/your/path/to/certificates/client_cert.pem", // Added field
        privateKeyFilepath: "/your/path/to/certificates/client_key.pem", // Added field
        caFilepath: "/your/path/to/certificates/client_truststore.pem",
        verifyMode: VerifyMode.Peer,
    }
});
```
IMHO I don't know if this feature flag is useful, but at least for me seems more like a easy way to turn it on/off. So, please let me know your thoughts on that.

> [!TIP]
> You can test with [this sample](https://github.com/DanielHe4rt/scylladb-role-tls-auth) by running `make setup` and then pointing your keys **absolute path** at the SSL object. Also, don't forget to switch your port to `9142` at the connection string.

## Changes

- [x] TLS/SSL with Keystore and Private Keys
- [x] Feature flag to enable/disable SSL.  
- [x] Simple example on how to use it.