### PR TITLE
feat(tracing): add query tracing for the session in the `executeWithTracing` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ scylla = { version = "0.13.1", features = [
 ] }
 uuid = { version = "1.4.1", features = ["serde", "v4", "fast-rng"] }
 serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]

--- a/examples/tracing.mts
+++ b/examples/tracing.mts
@@ -1,0 +1,18 @@
+import { Cluster } from "../index.js";
+
+const nodes = process.env.CLUSTER_NODES?.split(",") ?? ["127.0.0.1:9042"];
+
+console.log(`Connecting to ${nodes}`);
+
+const cluster = new Cluster({ nodes });
+const session = await cluster.connect();
+
+const { tracing } = await session.executeWithTracing(
+  "SELECT * FROM system_schema.scylla_tables",
+  [],
+  // {
+  //   prepare: true,
+  // },
+);
+
+console.log(tracing);

--- a/index.d.ts
+++ b/index.d.ts
@@ -157,6 +157,7 @@ export class Metrics {
 export class ScyllaSession {
   metrics(): Metrics
   getClusterData(): Promise<ScyllaClusterData>
+  executeWithTracing(query: string | Query | PreparedStatement, parameters?: Array<number | string | Uuid | Record<string, number | string | Uuid>> | undefined | null, options?: QueryOptions | undefined | null): Promise<any>
   /**
    * Sends a query to the database and receives a response.\
    * Returns only a single page of results, to receive multiple pages use (TODO: Not implemented yet)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,1 +1,2 @@
+pub mod tracing;
 pub mod uuid;

--- a/src/types/tracing.rs
+++ b/src/types/tracing.rs
@@ -1,0 +1,79 @@
+use std::{collections::HashMap, net::IpAddr};
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CqlTimestampWrapper(pub scylla::frame::value::CqlTimestamp);
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CqlTimeuuidWrapper(pub scylla::frame::value::CqlTimeuuid);
+
+impl Serialize for CqlTimestampWrapper {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    serializer.serialize_i64(self.0.0)
+  }
+}
+
+impl Serialize for CqlTimeuuidWrapper {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    serializer.serialize_str(format!("{}", self.0).as_str())
+  }
+}
+
+/// Tracing info retrieved from `system_traces.sessions`
+/// with all events from `system_traces.events`
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TracingInfo {
+  pub client: Option<IpAddr>,
+  pub command: Option<String>,
+  pub coordinator: Option<IpAddr>,
+  pub duration: Option<i32>,
+  pub parameters: Option<HashMap<String, String>>,
+  pub request: Option<String>,
+  /// started_at is a timestamp - time since unix epoch
+  pub started_at: Option<CqlTimestampWrapper>,
+
+  pub events: Vec<TracingEvent>,
+}
+
+/// A single event happening during a traced query
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TracingEvent {
+  pub event_id: CqlTimeuuidWrapper,
+  pub activity: Option<String>,
+  pub source: Option<IpAddr>,
+  pub source_elapsed: Option<i32>,
+  pub thread: Option<String>,
+}
+
+impl From<scylla::tracing::TracingInfo> for TracingInfo {
+  fn from(info: scylla::tracing::TracingInfo) -> Self {
+    Self {
+      client: info.client,
+      command: info.command,
+      coordinator: info.coordinator,
+      duration: info.duration,
+      parameters: info.parameters,
+      request: info.request,
+      started_at: info.started_at.map(CqlTimestampWrapper),
+      events: info.events.into_iter().map(TracingEvent::from).collect(),
+    }
+  }
+}
+
+impl From<scylla::tracing::TracingEvent> for TracingEvent {
+  fn from(event: scylla::tracing::TracingEvent) -> Self {
+    Self {
+      event_id: CqlTimeuuidWrapper(event.event_id),
+      activity: event.activity,
+      source: event.source,
+      source_elapsed: event.source_elapsed,
+      thread: event.thread,
+    }
+  }
+}

--- a/src/types/uuid.rs
+++ b/src/types/uuid.rs
@@ -1,7 +1,7 @@
 use napi::Result;
 
 #[napi()]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Uuid {
   pub(crate) uuid: uuid::Uuid,
 }


### PR DESCRIPTION
closes #42 