### PR TITLE
build: add MUSL target setup for CI builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,6 +110,12 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.settings.target }}
+      - name: Set up MUSL target and tools
+        if: ${{ contains(matrix.settings.target, 'musl') }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          rustup target add x86_64-unknown-linux-musl
       - name: Cache cargo
         uses: actions/cache@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
-          rustup target add x86_64-unknown-linux-musl
+          rustup target add ${{ matrix.settings.target }}
       - name: Cache cargo
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
This pull request includes an update to the CI configuration to support MUSL targets. The most important change is the addition of a step to set up MUSL target and tools in the CI workflow.

CI configuration updates:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R113-R118): Added a step to set up MUSL target and tools, including updating the package list, installing `musl-tools`, and adding the MUSL target using `rustup` if the target contains 'musl'.