### PR TITLE
ci: bump actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,7 +167,7 @@ jobs:
         if: ${{ !matrix.settings.docker }}
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bindings-${{ matrix.settings.target }}
           path: ${{ env.APP_NAME }}.*.node
@@ -273,7 +273,7 @@ jobs:
   #     - name: Combine binaries
   #       run: yarn universal
   #     - name: Upload artifact
-  #       uses: actions/upload-artifact@v3
+  #       uses: actions/upload-artifact@v4
   #       with:
   #         name: bindings-universal-apple-darwin
   #         path: ${{ env.APP_NAME }}.*.node


### PR DESCRIPTION
This PR includes an update to the GitHub Actions workflows to use the version v4 of the `upload-artifact` action.

This will try to fix the [error](https://github.com/Daniel-Boll/scylla-javascript-driver/actions/runs/11645518489/job/32428716038) where no artifact is found to publish.

[Action performed](https://github.com/gvieira18/scylla-javascript-driver/actions/runs/11645987650)
