### PR TITLE
fix: update package description, url and entrypoint name

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 env:
   DEBUG: napi:*
-  APP_NAME: package-template
+  APP_NAME: scylladb
   MACOSX_DEPLOYMENT_TARGET: "10.13"
   CARGO_INCREMENTAL: "1"
 permissions:

--- a/npm/android-arm-eabi/package.json
+++ b/npm/android-arm-eabi/package.json
@@ -4,11 +4,11 @@
   "cpu": [
     "arm"
   ],
-  "main": "package-template.android-arm-eabi.node",
+  "main": "scylladb.android-arm-eabi.node",
   "files": [
-    "package-template.android-arm-eabi.node"
+    "scylladb.android-arm-eabi.node"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -17,6 +17,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"
@@ -26,7 +31,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "os": [

--- a/npm/android-arm64/package.json
+++ b/npm/android-arm64/package.json
@@ -4,11 +4,11 @@
   "cpu": [
     "arm64"
   ],
-  "main": "package-template.android-arm64.node",
+  "main": "scylladb.android-arm64.node",
   "files": [
-    "package-template.android-arm64.node"
+    "scylladb.android-arm64.node"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -17,6 +17,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"
@@ -26,7 +31,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "os": [

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -4,11 +4,11 @@
   "cpu": [
     "arm64"
   ],
-  "main": "package-template.darwin-arm64.node",
+  "main": "scylladb.darwin-arm64.node",
   "files": [
-    "package-template.darwin-arm64.node"
+    "scylladb.darwin-arm64.node"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -17,6 +17,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"
@@ -26,7 +31,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "os": [

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -4,11 +4,11 @@
   "cpu": [
     "x64"
   ],
-  "main": "package-template.darwin-x64.node",
+  "main": "scylladb.darwin-x64.node",
   "files": [
-    "package-template.darwin-x64.node"
+    "scylladb.darwin-x64.node"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -17,6 +17,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"
@@ -26,7 +31,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "os": [

--- a/npm/freebsd-x64/package.json
+++ b/npm/freebsd-x64/package.json
@@ -4,11 +4,11 @@
   "cpu": [
     "x64"
   ],
-  "main": "package-template.freebsd-x64.node",
+  "main": "scylladb.freebsd-x64.node",
   "files": [
-    "package-template.freebsd-x64.node"
+    "scylladb.freebsd-x64.node"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -17,6 +17,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"
@@ -26,7 +31,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "os": [

--- a/npm/linux-arm-gnueabihf/package.json
+++ b/npm/linux-arm-gnueabihf/package.json
@@ -4,11 +4,11 @@
   "cpu": [
     "arm"
   ],
-  "main": "package-template.linux-arm-gnueabihf.node",
+  "main": "scylladb.linux-arm-gnueabihf.node",
   "files": [
-    "package-template.linux-arm-gnueabihf.node"
+    "scylladb.linux-arm-gnueabihf.node"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -17,6 +17,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"
@@ -26,7 +31,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "os": [

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -4,11 +4,11 @@
   "cpu": [
     "arm64"
   ],
-  "main": "package-template.linux-arm64-gnu.node",
+  "main": "scylladb.linux-arm64-gnu.node",
   "files": [
-    "package-template.linux-arm64-gnu.node"
+    "scylladb.linux-arm64-gnu.node"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -17,6 +17,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"
@@ -26,7 +31,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "os": [

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -4,11 +4,11 @@
   "cpu": [
     "arm64"
   ],
-  "main": "package-template.linux-arm64-musl.node",
+  "main": "scylladb.linux-arm64-musl.node",
   "files": [
-    "package-template.linux-arm64-musl.node"
+    "scylladb.linux-arm64-musl.node"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -17,6 +17,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"
@@ -26,7 +31,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "os": [

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -4,11 +4,11 @@
   "cpu": [
     "x64"
   ],
-  "main": "package-template.linux-x64-gnu.node",
+  "main": "scylladb.linux-x64-gnu.node",
   "files": [
-    "package-template.linux-x64-gnu.node"
+    "scylladb.linux-x64-gnu.node"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -17,6 +17,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"
@@ -26,7 +31,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "os": [

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -4,11 +4,11 @@
   "cpu": [
     "x64"
   ],
-  "main": "package-template.linux-x64-musl.node",
+  "main": "scylladb.linux-x64-musl.node",
   "files": [
-    "package-template.linux-x64-musl.node"
+    "scylladb.linux-x64-musl.node"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -17,6 +17,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"
@@ -26,7 +31,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "os": [

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -4,15 +4,15 @@
   "cpu": [
     "wasm32"
   ],
-  "main": "package-template.wasi.cjs",
+  "main": "scylladb.wasi.cjs",
   "files": [
-    "package-template.wasm32-wasi.wasm",
-    "package-template.wasi.cjs",
-    "package-template.wasi-browser.js",
+    "scylladb.wasm32-wasi.wasm",
+    "scylladb.wasi.cjs",
+    "scylladb.wasi-browser.js",
     "wasi-worker.mjs",
     "wasi-worker-browser.mjs"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -21,6 +21,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">=14.0.0"
@@ -30,10 +35,10 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
-  "browser": "package-template.wasi-browser.js",
+  "browser": "scylladb.wasi-browser.js",
   "dependencies": {
     "@napi-rs/wasm-runtime": "^0.2.5"
   }

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -4,11 +4,11 @@
   "cpu": [
     "arm64"
   ],
-  "main": "package-template.win32-arm64-msvc.node",
+  "main": "scylladb.win32-arm64-msvc.node",
   "files": [
-    "package-template.win32-arm64-msvc.node"
+    "scylladb.win32-arm64-msvc.node"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -17,6 +17,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"
@@ -26,7 +31,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "os": [

--- a/npm/win32-ia32-msvc/package.json
+++ b/npm/win32-ia32-msvc/package.json
@@ -4,11 +4,11 @@
   "cpu": [
     "ia32"
   ],
-  "main": "package-template.win32-ia32-msvc.node",
+  "main": "scylladb.win32-ia32-msvc.node",
   "files": [
-    "package-template.win32-ia32-msvc.node"
+    "scylladb.win32-ia32-msvc.node"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -17,6 +17,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"
@@ -26,7 +31,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "os": [

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -4,11 +4,11 @@
   "cpu": [
     "x64"
   ],
-  "main": "package-template.win32-x64-msvc.node",
+  "main": "scylladb.win32-x64-msvc.node",
   "files": [
-    "package-template.win32-x64-msvc.node"
+    "scylladb.win32-x64-msvc.node"
   ],
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "keywords": [
     "napi-rs",
     "NAPI",
@@ -17,6 +17,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"
@@ -26,7 +31,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "os": [

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@lambda-group/scylladb",
   "version": "1.1.1",
-  "description": "Template project for writing node package with napi-rs",
+  "description": "🚀 JavaScript driver for ScyllaDB, harnessing Rust's power through napi-rs for top performance. Pre-release stage. 🧪🔧",
   "main": "index.js",
   "types": "index.d.ts",
   "browser": "browser.js",
   "repository": {
-    "url": "git+ssh://git@github.com/napi-rs/package-template-pnpm.git",
+    "url": "git+https://github.com/Daniel-Boll/scylla-javascript-driver.git",
     "type": "git"
   },
   "license": "MIT",
@@ -18,6 +18,11 @@
     "node-addon",
     "node-addon-api"
   ],
+  "author": {
+    "name": "Daniel Boll",
+    "email": "danielboll.dev@proton.me",
+    "url": "https://daniel-boll.me"
+  },
   "files": [
     "index.d.ts",
     "index.js",

--- a/src/helpers/query_parameter.rs
+++ b/src/helpers/query_parameter.rs
@@ -1,7 +1,7 @@
 use scylla::serialize::{
-  RowWriter, SerializationError,
   row::{RowSerializationContext, SerializeRow},
   value::SerializeCql,
+  RowWriter, SerializationError,
 };
 
 use super::{cql_value_bridge::ParameterWithMapType, to_cql_value::ToCqlValue};

--- a/src/helpers/query_results.rs
+++ b/src/helpers/query_results.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use napi::bindgen_prelude::{BigInt, Either9, Either10, Either11};
+use napi::bindgen_prelude::{BigInt, Either10, Either11, Either9};
 use scylla::frame::response::result::{ColumnType, CqlValue};
 
 use crate::types::{decimal::Decimal, duration::Duration, uuid::Uuid};

--- a/src/session/scylla_session.rs
+++ b/src/session/scylla_session.rs
@@ -6,8 +6,8 @@ use crate::query::scylla_prepared_statement::PreparedStatement;
 use crate::query::scylla_query::Query;
 use crate::types::tracing::TracingReturn;
 use crate::types::uuid::Uuid;
-use napi::Either;
 use napi::bindgen_prelude::Either3;
+use napi::Either;
 use scylla::statement::query::Query as ScyllaQuery;
 
 use super::metrics;

--- a/src/types/tracing.rs
+++ b/src/types/tracing.rs
@@ -15,7 +15,7 @@ impl Serialize for CqlTimestampWrapper {
   where
     S: serde::Serializer,
   {
-    serializer.serialize_i64(self.0.0)
+    serializer.serialize_i64(self.0 .0)
   }
 }
 


### PR DESCRIPTION
This PR includes several changes that are missing from the main branch migration. Among them, the most important change (I think) is the entry point it used to point to in the template.

And also, I got the old url that is used to push reference package.json before from [previous ran pipeline](https://github.com/Daniel-Boll/scylla-javascript-driver/actions/runs/11646438848/job/32430535683).

![image](https://github.com/user-attachments/assets/630faaf6-0f01-4d21-93e8-4f000b72ce13)
