### PR TITLE
fix: target build and `cargo fmt` issues

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"

--- a/src/cluster/scylla_cluster.rs
+++ b/src/cluster/scylla_cluster.rs
@@ -5,7 +5,7 @@ use openssl::ssl::{SslContextBuilder, SslFiletype};
 
 use crate::{
   cluster::{
-    cluster_config::{ClusterConfig, compression::Compression},
+    cluster_config::{compression::Compression, ClusterConfig},
     execution_profile::ExecutionProfile,
   },
   session::scylla_session::ScyllaSession,

--- a/src/helpers/query_parameter.rs
+++ b/src/helpers/query_parameter.rs
@@ -1,7 +1,7 @@
 use scylla::serialize::{
-  RowWriter, SerializationError,
   row::{RowSerializationContext, SerializeRow},
   value::SerializeCql,
+  RowWriter, SerializationError,
 };
 
 use super::{cql_value_bridge::ParameterWithMapType, to_cql_value::ToCqlValue};

--- a/src/helpers/query_results.rs
+++ b/src/helpers/query_results.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use napi::bindgen_prelude::{BigInt, Either9, Either10, Either11};
+use napi::bindgen_prelude::{BigInt, Either10, Either11, Either9};
 use scylla::frame::response::result::{ColumnType, CqlValue};
 
 use crate::types::{decimal::Decimal, duration::Duration, uuid::Uuid};

--- a/src/session/scylla_session.rs
+++ b/src/session/scylla_session.rs
@@ -6,8 +6,8 @@ use crate::query::scylla_prepared_statement::PreparedStatement;
 use crate::query::scylla_query::Query;
 use crate::types::tracing::TracingReturn;
 use crate::types::uuid::Uuid;
-use napi::Either;
 use napi::bindgen_prelude::Either3;
+use napi::Either;
 use scylla::statement::query::Query as ScyllaQuery;
 
 use super::metrics;

--- a/src/session/topology.rs
+++ b/src/session/topology.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use napi::bindgen_prelude::Either3;
-use scylla::transport::ClusterData;
 use scylla::transport::topology::{Keyspace, MaterializedView, Strategy, Table};
+use scylla::transport::ClusterData;
 
 // ============= ClusterData ============= //
 #[napi]

--- a/src/types/tracing.rs
+++ b/src/types/tracing.rs
@@ -15,7 +15,7 @@ impl Serialize for CqlTimestampWrapper {
   where
     S: serde::Serializer,
   {
-    serializer.serialize_i64(self.0.0)
+    serializer.serialize_i64(self.0 .0)
   }
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve code organization and update the toolchain configuration. The most important changes include switching the Rust toolchain channel from nightly to stable and reorganizing imports across multiple files for better readability and consistency.

Toolchain update:

* [`rust-toolchain.toml`](diffhunk://#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eL2-R2): Changed the Rust toolchain channel from `nightly` to `stable`.

Import reorganization:

* [`src/cluster/scylla_cluster.rs`](diffhunk://#diff-a328ddcad66c7331981f0504e0e7c898b94bb7627b3dc3749bd2953f65a1a3ccL8-R8): Reordered imports for `ClusterConfig` and `Compression` to improve readability.
* [`src/helpers/query_parameter.rs`](diffhunk://#diff-e6b61072519444eb27a091fedb6a7844299039dc6f7689a72ed61c8d16fa8cd1L2-R4): Reorganized imports for `RowWriter` and `SerializationError` for consistency.
* [`src/helpers/query_results.rs`](diffhunk://#diff-c46f185a1370949dddf3212dc1936e62a30f230871954ff78ac2119f8611b0a5L3-R3): Reordered `napi::bindgen_prelude` imports for better readability.
* [`src/session/scylla_session.rs`](diffhunk://#diff-5d57737517755d2efee92f675121d13b74122292d129d971a4a1baff5a9f5032L9-R10): Moved `napi::Either` import to maintain consistent import order.
* [`src/session/topology.rs`](diffhunk://#diff-0021f8a05dab631179ba1f51c0e5c0371537704b22bb2d32b1069e0ceec30a45L5-R6): Reorganized `scylla::transport::ClusterData` import for better readability.